### PR TITLE
fix: npm packages didn't publish types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/WangShayne/vue3-signature"
   },
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "main": "./dist/vue3-signature.umd.js",
   "module": "./dist/vue3-signature.es.js",


### PR DESCRIPTION
This is the following up fix for #13 that I forgot to include `types` folder in the published package.
I think you should publish a new fix patch after this PR. Sorry!